### PR TITLE
updates to build with template-haskell 2.16-2.18

### DIFF
--- a/Control/Enumerable/Derive.hs
+++ b/Control/Enumerable/Derive.hs
@@ -33,9 +33,15 @@ extractData n = reify n >>= \i -> return $ case i of
   TyConI (NewtypeD cxt _ tvbs con _) -> (cxt, map tvbName tvbs, [con])
 #endif
 
+#if MIN_VERSION_template_haskell(2,17,0)
+tvbName :: TyVarBndr flag -> Name
+tvbName (PlainTV n _)    = n
+tvbName (KindedTV n _ _) = n
+#else
 tvbName :: TyVarBndr -> Name
 tvbName (PlainTV n)  = n
 tvbName (KindedTV n _) = n
+#endif
 
 
 conData :: Con -> Q (Name,[Type])

--- a/size-based.cabal
+++ b/size-based.cabal
@@ -31,7 +31,7 @@ library
   build-depends:       base >=4.7 && <5,
                        dictionary-sharing >= 0.1 && < 1.0,
                        testing-type-modifiers >= 0.1 && < 1.0,
-                       template-haskell  >=2.5 && <2.16
+                       template-haskell  >=2.5 && <2.18
   if impl(ghc < 8.0)
     build-depends: semigroups < 0.19
   default-language:    Haskell2010

--- a/size-based.cabal
+++ b/size-based.cabal
@@ -31,7 +31,7 @@ library
   build-depends:       base >=4.7 && <5,
                        dictionary-sharing >= 0.1 && < 1.0,
                        testing-type-modifiers >= 0.1 && < 1.0,
-                       template-haskell  >=2.5 && <2.18
+                       template-haskell  >=2.5 && <2.19
   if impl(ghc < 8.0)
     build-depends: semigroups < 0.19
   default-language:    Haskell2010


### PR DESCRIPTION
This PR is a clone of https://github.com/JonasDuregard/sized-functors/pull/10 .  Once we merge this we should also update to build with `template-haskell-2.18` and GHC 9.2, as discussed in the comments there.